### PR TITLE
Fix missing discrete legend for GeoPandas categorical maps

### DIFF
--- a/reference/example.qmd
+++ b/reference/example.qmd
@@ -296,6 +296,8 @@ def map_plot_mpl(fig, axs, world):
 map_plot_mpl(world)
 ```
 
+If you map **categorical** values (for example, areas of control), set `categorical=True` and `legend=True` in `geopandas.plot(...)`; the discrete in-axes map legend is preserved under `@wb_plot`.
+
 ### `plotly`
 
 ```{python}

--- a/wbpyplot/decorator.py
+++ b/wbpyplot/decorator.py
@@ -342,6 +342,10 @@ def _render_mpl(
     # --- Titles, subtitles, notes, legend layout ---
     fig.canvas.draw()
     handles, labels = axs[0].get_legend_handles_labels()
+    existing_ax_legend = axs[0].get_legend()
+    # GeoPandas categorical maps can build an in-axes Legend artist while
+    # get_legend_handles_labels() still returns empty; preserve that legend.
+    has_in_axes_only_legend = existing_ax_legend is not None and len(handles) == 0 and len(labels) == 0
 
     if should_suppress_legend(handles, labels):
         handles, labels = [], []
@@ -417,9 +421,10 @@ def _render_mpl(
         # subplots_adjust should still provide reasonable spacing
         pass
 
-    # Remove any in-axes legend before rendering the custom one
-    if axs[0].get_legend():
-        axs[0].get_legend().remove()
+    # Remove in-axes legend only when replacing with the WB custom legend.
+    # Keep map legends that exist as in-axes Legend artists only.
+    if show_legend and existing_ax_legend and not has_in_axes_only_legend:
+        existing_ax_legend.remove()
 
     fig.canvas.draw()
 


### PR DESCRIPTION
## Summary
- Preserve in-axes GeoPandas categorical map legends when `@wb_plot` would otherwise remove them because `get_legend_handles_labels()` returns empty handles/labels.
- Only remove the in-axes legend when the decorator is replacing it with the custom WB bottom legend.
- Document categorical map legend usage in the reference examples.

Fixes #30.

## Test plan
- [x] Reproduce GeoPandas categorical map with `legend=True` and confirm legend remains after `@wb_plot`
- [x] Verify line chart still uses custom WB figure legend
- [x] Verify bar chart still uses custom WB figure legend
- [x] Verify charts without legends remain unchanged
