### PR TITLE
Add bar_labels option to disable automatic bar value labels

### DIFF
--- a/wbpyplot/axis.py
+++ b/wbpyplot/axis.py
@@ -6,7 +6,7 @@ import numpy as np
 from .number_formatting import format_number
 
 
-def apply_axis_styling(ax, wb_font_sizes, wb_spacing, chart_type, is_multi_panel=False):
+def apply_axis_styling(ax, wb_font_sizes, wb_spacing, chart_type, is_multi_panel=False, bar_labels=True):
     # --- shared axis label + tick styling ---
     for axis in [ax.xaxis, ax.yaxis]:
         axis.label.set_fontsize(wb_font_sizes["s"])
@@ -131,16 +131,17 @@ def apply_axis_styling(ax, wb_font_sizes, wb_spacing, chart_type, is_multi_panel
             add_zero_line_h()
 
         # --- bar value labels ---
-        for container in ax.containers:
-            ax.bar_label(
-                container,
-                fmt="%.0f",
-                label_type="edge",
-                padding=2,
-                fontsize=wb_font_sizes["s"],
-                fontweight="semibold",
-                color="#111111",
-            )
+        if bar_labels:
+            for container in ax.containers:
+                ax.bar_label(
+                    container,
+                    fmt="%.0f",
+                    label_type="edge",
+                    padding=2,
+                    fontsize=wb_font_sizes["s"],
+                    fontweight="semibold",
+                    color="#111111",
+                )
 
 
 

--- a/wbpyplot/decorator.py
+++ b/wbpyplot/decorator.py
@@ -38,6 +38,7 @@ def wb_plot(
     include_insets=False,
     backend="mpl",
     show=True,
+    bar_labels=True,
 ):
     """
     Create a standardized plotting theme via a decorator for the World Bank with consistent styling,
@@ -94,6 +95,9 @@ def wb_plot(
     show : bool, default=True
         Whether to automatically display the figure. If ``False``, the figure
         is created but not shown (useful for programmatic use).
+    bar_labels : bool, default=True
+        Whether to add value labels on bar charts (Matplotlib and Plotly).
+        Set to ``False`` to omit automatic bar value labels.
 
     Notes
     -----
@@ -183,6 +187,7 @@ def wb_plot(
                     palette_bin_mode=palette_bin_mode,
                     include_insets=include_insets,
                     show=show,
+                    bar_labels=bar_labels,
                 )
             elif backend == "plotly":
                 return _render_plotly(
@@ -199,6 +204,7 @@ def wb_plot(
                     palette=palette,
                     palette_n=palette_n,
                     show=show,
+                    bar_labels=bar_labels,
                 )
             else:
                 raise ValueError(
@@ -231,6 +237,7 @@ def _render_mpl(
     palette_bin_mode,
     include_insets,
     show,
+    bar_labels,
 ):
     """Render using Matplotlib backend."""
     # Apply global rcparams/theme
@@ -322,7 +329,11 @@ def _render_mpl(
     # Axes styling / tidy ticks
     for ax in axes_for_styling:
         chart_type = detect_chart_type(ax)
-        apply_axis_styling(ax, font_sizes, spacing, chart_type, is_multi_panel=is_multi_panel)
+        apply_axis_styling(
+            ax, font_sizes, spacing, chart_type,
+            is_multi_panel=is_multi_panel,
+            bar_labels=bar_labels,
+        )
         tidy_numeric_ticks(ax, max_ticks=5, chart_type=chart_type)
 
     # Scatter markers: larger size with white outline
@@ -521,6 +532,7 @@ def _render_plotly(
     palette,
     palette_n,
     show,
+    bar_labels,
 ):
     """Render using Plotly backend."""
     try:
@@ -664,7 +676,7 @@ def _render_plotly(
     is_bar_chart_horizontal = any(
         getattr(t, "orientation", None) == "h" for t in fig.data if getattr(t, "type", None) == "bar"
     ) if has_bar else False
-    if has_bar:
+    if has_bar and bar_labels:
         def _bar_fmt(v):
             if isinstance(v, (int, float)):
                 return str(int(v)) if v == int(v) else str(round(v, 2))


### PR DESCRIPTION
## Summary
- Add `bar_labels` parameter to `@wb_plot` (default `True` for backward compatibility).
- When `bar_labels=False`, skip automatic value labels on bar charts in both Matplotlib and Plotly backends.

Fixes #32.

## Test plan
- [x] `bar_labels=True` (default): bar charts still show value labels on bars
- [x] `bar_labels=False`: no automatic value labels added